### PR TITLE
fix: do not delay initial upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,14 +270,14 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.60</minimum>
                                             <!--TODO: Increase the coverage. Currently some of the service code is
                                             not testable.-->
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.60</minimum>
                                             <!--TODO: Increase the coverage. Currently some of the service code is
                                             not testable.-->
                                         </limit>

--- a/src/main/java/com/aws/greengrass/detector/IpDetectorManager.java
+++ b/src/main/java/com/aws/greengrass/detector/IpDetectorManager.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.detector;
 
 import com.aws.greengrass.detector.detector.IpDetector;

--- a/src/main/java/com/aws/greengrass/detector/IpDetectorService.java
+++ b/src/main/java/com/aws/greengrass/detector/IpDetectorService.java
@@ -7,8 +7,8 @@ package com.aws.greengrass.detector;
 
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.ImplementsService;
+import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.PluginService;
-import org.apache.commons.lang3.RandomUtils;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -19,7 +19,6 @@ import javax.inject.Inject;
 @ImplementsService(name = IpDetectorService.DECTECTOR_SERVICE_NAME)
 public class IpDetectorService extends PluginService {
     public static final String DECTECTOR_SERVICE_NAME = "aws.greengrass.clientdevices.IPDetector";
-    public static final int DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC = 180;
     private final IpDetectorManager ipDetectorManager;
     private final ScheduledExecutorService scheduledExecutorService;
     private Future<?> future;
@@ -41,19 +40,16 @@ public class IpDetectorService extends PluginService {
     }
 
     /**
-     * Start Ip Detection service.
+     * Start IP Detection service.
      *
      * @throws  InterruptedException if the thread interrupted
      */
     @Override
     public void startup() throws InterruptedException {
-        super.startup();
-        logger.atInfo().log("Starting ...");
-        long initialDelay = RandomUtils.nextLong(0, DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC);
-        Future<?> future = scheduledExecutorService.scheduleAtFixedRate(() -> {
+        this.future = scheduledExecutorService.scheduleAtFixedRate(() -> {
             ipDetectorManager.startIpDetection();
-        }, initialDelay, 60, TimeUnit.SECONDS);
-        this.future = future;
+        }, 0, 60, TimeUnit.SECONDS);
+        reportState(State.RUNNING);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/detector/config/Config.java
+++ b/src/main/java/com/aws/greengrass/detector/config/Config.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.detector.config;
 
 import lombok.Getter;

--- a/src/main/java/com/aws/greengrass/detector/detector/IpDetector.java
+++ b/src/main/java/com/aws/greengrass/detector/detector/IpDetector.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.detector.detector;
 
 import java.net.Inet6Address;

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.detector.uploader;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
IP detector should upload initial connectivity information immediately upon starting. Delaying this will prevent client devices from discovering and connecting to Greengrass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
