### PR TITLE
Internet connection error reporting

### DIFF
--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import lombok.NonNull;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
+import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoResponse;
 
@@ -72,7 +73,7 @@ public class ConnectivityUpdater {
                 this.ipAddresses = ips;
                 logger.atInfo().kv("IPs", ips).log("Uploaded IP addresses");
             }
-        } catch (SdkClientException e) {
+        } catch (GreengrassV2DataException | SdkClientException e) {
             Throwable cause = e.getCause();
 
             if (cause instanceof UnknownHostException) {

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -78,7 +78,8 @@ public class ConnectivityUpdater {
             if (cause instanceof UnknownHostException) {
                 // Let the user know if Internet connectivity is lost so they do not try to debug their IAM policies immediately
                 logger.atWarn()
-                        .log("Failed to upload the IP addresses. An unknown host exception was thrown. This may indicate that Internet connectivity has been lost.");
+                        .log("Failed to upload the IP addresses. An unknown host exception was thrown. "
+                                + "This may indicate that Internet connectivity has been lost.");
 
                 return;
             }

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -76,7 +76,8 @@ public class ConnectivityUpdater {
             Throwable cause = e.getCause();
 
             if (cause instanceof UnknownHostException) {
-                // Let the user know if Internet connectivity is lost so they do not try to debug their IAM policies immediately
+                // Let the user know if Internet connectivity is lost so they do not try to debug their IAM policies
+                //   immediately
                 logger.atWarn()
                         .log("Failed to upload the IP addresses. An unknown host exception was thrown. "
                                 + "This may indicate that Internet connectivity has been lost.");

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -12,7 +12,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import lombok.NonNull;
-import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoResponse;
@@ -72,7 +72,7 @@ public class ConnectivityUpdater {
                 this.ipAddresses = ips;
                 logger.atInfo().kv("IPs", ips).log("Uploaded IP addresses");
             }
-        } catch (SdkException e) {
+        } catch (SdkClientException e) {
             Throwable cause = e.getCause();
 
             if (cause instanceof UnknownHostException) {

--- a/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
+++ b/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;

--- a/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
+++ b/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;


### PR DESCRIPTION
**Description of changes:**
This change will report if there are Internet connectivity issues when attempting to update the connectivity info

**Why is this change necessary:**
A customer asked about their Greengrass V2 policy and referenced this error message. It turns out that the real cause of the issue is that the Internet connection was down and an UnknownHostException was thrown. This change adds a new error message that will tell customers that their Internet connection is down so that they won't immediately jump to debugging their IAM policies.

**Any additional information or context required to review the change:**
I'm an AWS employee

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
