### PR TITLE
fix: handle null response from getGreengrassV2DataClient

### DIFF
--- a/src/main/java/com/aws/greengrass/detector/IpDetectorManager.java
+++ b/src/main/java/com/aws/greengrass/detector/IpDetectorManager.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.detector;
 
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.detector.config.Config;
 import com.aws.greengrass.detector.detector.IpDetector;
 import com.aws.greengrass.detector.uploader.ConnectivityUpdater;
@@ -34,7 +35,7 @@ public class IpDetectorManager {
         this.connectivityUpdater = connectivityUpdater;
     }
 
-    void updateIps(Config config) {
+    void updateIps(Config config) throws DeviceConfigurationException {
         List<InetAddress> ipAddresses = null;
         try {
             ipAddresses = ipDetector.getAllIpAddresses(config);

--- a/src/test/java/com/aws/greengrass/detector/IpDetectorManagerTest.java
+++ b/src/test/java/com/aws/greengrass/detector/IpDetectorManagerTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.detector;
 
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.detector.config.Config;
 import com.aws.greengrass.detector.detector.IpDetector;
 import com.aws.greengrass.detector.uploader.ConnectivityUpdater;
@@ -37,7 +38,8 @@ public class IpDetectorManagerTest {
     IpDetectorManager ipDetectorManager;
 
     @Test
-    public void GIVEN_ip_addresses_found_WHEN_initialize_THEN_upload_called() throws SocketException {
+    public void GIVEN_ip_addresses_found_WHEN_initialize_THEN_upload_called()
+            throws SocketException, DeviceConfigurationException {
         ipDetectorManager = new IpDetectorManager(connectivityUpdater, ipDetector);
         List <InetAddress> ips = new ArrayList<>();
         ips.add(Mockito.mock(InetAddress.class));
@@ -47,7 +49,8 @@ public class IpDetectorManagerTest {
     }
 
     @Test
-    public void GIVEN_ip_addresses_not_found_WHEN_initialize_THEN_upload_called() throws SocketException {
+    public void GIVEN_ip_addresses_not_found_WHEN_initialize_THEN_upload_called()
+            throws SocketException, DeviceConfigurationException {
         ipDetectorManager = new IpDetectorManager(connectivityUpdater, ipDetector);
         when(ipDetector.getAllIpAddresses(any(Config.class))).thenReturn(new ArrayList<>());
         ipDetectorManager.updateIps(config);

--- a/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
+++ b/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.detector.uploader;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.detector.config.Config;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.utils.TestConstants;
@@ -56,7 +57,8 @@ public class ConnectivityUpdaterTest {
     }
 
     @Test
-    public void GIVEN_ip_addresses_WHEN_updateIpAddresses_THEN_update_conn_called() {
+    public void GIVEN_ip_addresses_WHEN_updateIpAddresses_THEN_update_conn_called()
+            throws DeviceConfigurationException {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
         Mockito.doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         connectivityUpdater = new ConnectivityUpdater(deviceConfiguration, clientFactory);
@@ -70,7 +72,7 @@ public class ConnectivityUpdaterTest {
     }
 
     @Test
-    public void GIVEN_ip_addresses_WHEN_updateIpAddresses_throws_THEN_passes() {
+    public void GIVEN_ip_addresses_WHEN_updateIpAddresses_throws_THEN_passes() throws DeviceConfigurationException {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
         Mockito.doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         connectivityUpdater = new ConnectivityUpdater(deviceConfiguration, clientFactory);
@@ -82,7 +84,8 @@ public class ConnectivityUpdaterTest {
     }
 
     @Test
-    public void GIVEN_ip_addresses_WHEN_updateIpAddresses_and_null_THEN_update_conn_not_called() {
+    public void GIVEN_ip_addresses_WHEN_updateIpAddresses_and_null_THEN_update_conn_not_called()
+            throws DeviceConfigurationException {
         connectivityUpdater = new ConnectivityUpdater(deviceConfiguration, clientFactory);
         connectivityUpdater.updateIpAddresses(null, Mockito.mock(Config.class));
         verify(greengrassV2DataClient, times(0))
@@ -92,7 +95,8 @@ public class ConnectivityUpdaterTest {
     }
 
     @Test
-    public void GIVEN_ip_addresses_WHEN_updateIpAddressesFails_THEN_ip_list_not_updated() {
+    public void GIVEN_ip_addresses_WHEN_updateIpAddressesFails_THEN_ip_list_not_updated()
+            throws DeviceConfigurationException {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
         Mockito.doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         Mockito.doReturn(UpdateConnectivityInfoResponse.builder().version("1").build())


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle null response from getGreengrassV2DataClient

**Why is this change necessary:**
Needed to avoid NPE when getGreengrassV2DataClient returns null

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
