### PR TITLE
fix: check root cause of offline exceptions

### DIFF
--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -91,10 +91,10 @@ public class ConnectivityUpdater {
             if (e instanceof SdkServiceException
                     && HttpStatusCode.FORBIDDEN == ((SdkServiceException) e).statusCode()) {
                 logger.atWarn()
-                        .log("Failed to upload the IP addresses. Make sure that the core device's IoT policy grants the "
-                                + "greengrass:UpdateConnectivityInfo permission. " +
-                                "Also the Greengrass service role must be associated to your AWS account with the " +
-                                "iot:GetThingShadow and iot:UpdateThingShadow permissions.", e);
+                        .log("Failed to upload the IP addresses. Make sure that the core device's IoT policy "
+                                + "grants the greengrass:UpdateConnectivityInfo permission. "
+                                + "Also the Greengrass service role must be associated to your AWS account with the "
+                                + "iot:GetThingShadow and iot:UpdateThingShadow permissions.", e);
                 return;
             }
             // Catch all error message

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.Utils;
 import lombok.NonNull;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
@@ -76,7 +77,7 @@ public class ConnectivityUpdater {
                 logger.atInfo().kv("IPs", ips).kv("defaultPort", defaultPort).log("Uploaded IP addresses");
             }
         } catch (GreengrassV2DataException | SdkClientException e) {
-            Throwable cause = e.getCause();
+            Throwable cause = Utils.getUltimateCause(e);
 
             if (cause instanceof UnknownHostException) {
                 // Let the user know if Internet connectivity is lost so they do not try to debug their IAM policies

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -91,8 +91,10 @@ public class ConnectivityUpdater {
             if (e instanceof SdkServiceException
                     && HttpStatusCode.FORBIDDEN == ((SdkServiceException) e).statusCode()) {
                 logger.atWarn()
-                        .log("Failed to upload the IP addresses. Check that the core device's IoT policy grants the "
-                                + "greengrass:UpdateConnectivityInfo permission.", e);
+                        .log("Failed to upload the IP addresses. Make sure that the core device's IoT policy grants the "
+                                + "greengrass:UpdateConnectivityInfo permission. " +
+                                "Also the Greengrass service role must be associated to your AWS account with the " +
+                                "iot:GetThingShadow and iot:UpdateThingShadow permissions.", e);
                 return;
             }
             // Catch all error message

--- a/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
+++ b/src/main/java/com/aws/greengrass/detector/uploader/ConnectivityUpdater.java
@@ -13,9 +13,8 @@ import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Utils;
 import lombok.NonNull;
-import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
-import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoResponse;
 
@@ -76,7 +75,7 @@ public class ConnectivityUpdater {
                 this.defaultPort = defaultPort;
                 logger.atInfo().kv("IPs", ips).kv("defaultPort", defaultPort).log("Uploaded IP addresses");
             }
-        } catch (GreengrassV2DataException | SdkClientException e) {
+        } catch (SdkException e) {
             Throwable cause = Utils.getUltimateCause(e);
 
             if (cause instanceof UnknownHostException) {

--- a/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
+++ b/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
@@ -19,6 +19,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;
@@ -93,6 +95,16 @@ public class ConnectivityUpdaterTest {
                 .cause(new UnknownHostException()).build();
         when(greengrassV2DataClient.updateConnectivityInfo(Mockito.any(UpdateConnectivityInfoRequest.class)))
                 .thenThrow(SdkException.builder().cause(sdkClientException).build());
+        List<String> ips = Collections.singletonList(TestConstants.IPV4_LOOPBACK);
+        connectivityUpdater.uploadAddresses(ips, Mockito.mock(Config.class));
+    }
+
+    @Test
+    public void GIVEN_ip_addresses_WHEN_uploadAddresses_forbidden_THEN_passes() {
+        connectivityUpdater = new ConnectivityUpdater(deviceConfiguration, clientFactory);
+        SdkServiceException forbidden = SdkServiceException.builder().statusCode(HttpStatusCode.FORBIDDEN).build();
+        when(greengrassV2DataClient.updateConnectivityInfo(Mockito.any(UpdateConnectivityInfoRequest.class)))
+                .thenThrow(forbidden);
         List<String> ips = Collections.singletonList(TestConstants.IPV4_LOOPBACK);
         connectivityUpdater.uploadAddresses(ips, Mockito.mock(Config.class));
     }

--- a/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
+++ b/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.services.greengrassv2data.model.UpdateConnectivityInfoRequest;
@@ -91,7 +92,7 @@ public class ConnectivityUpdaterTest {
         SdkClientException sdkClientException = SdkClientException.builder()
                 .cause(new UnknownHostException()).build();
         when(greengrassV2DataClient.updateConnectivityInfo(Mockito.any(UpdateConnectivityInfoRequest.class)))
-                .thenThrow(sdkClientException);
+                .thenThrow(SdkException.builder().cause(sdkClientException).build());
         List<String> ips = Collections.singletonList(TestConstants.IPV4_LOOPBACK);
         connectivityUpdater.uploadAddresses(ips, Mockito.mock(Config.class));
     }

--- a/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
+++ b/src/test/java/com/aws/greengrass/detector/uploader/ConnectivityUpdaterTest.java
@@ -86,8 +86,6 @@ public class ConnectivityUpdaterTest {
 
     @Test
     public void GIVEN_ip_addresses_WHEN_offline_uploadAddresses_THEN_passes() {
-        Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
-        Mockito.doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         connectivityUpdater = new ConnectivityUpdater(deviceConfiguration, clientFactory);
         // Cause UnknownHostException to simulate offline device
         SdkClientException sdkClientException = SdkClientException.builder()


### PR DESCRIPTION
**Issue #, if available:** `UnknownHostException` may not be the immediate cause of the thrown exception while offline.

**Description of changes:** fix checks the root cause

**How was this change tested:** unit tests (mvn clean pckage)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
