### PR TITLE
fix: drop ip acquired to debug log level

### DIFF
--- a/src/main/java/com/aws/greengrass/detector/IpDetectorManager.java
+++ b/src/main/java/com/aws/greengrass/detector/IpDetectorManager.java
@@ -38,7 +38,7 @@ public class IpDetectorManager {
         List<InetAddress> ipAddresses = null;
         try {
             ipAddresses = ipDetector.getAllIpAddresses(config);
-            logger.atInfo().kv("IpAddresses", ipAddresses)
+            logger.atDebug().kv("IpAddresses", ipAddresses)
                     .log("Acquired host IP addresses");
             if (ipAddresses.isEmpty()) {
                 return;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Drop down the log level to stop spamming logs with useless stuff

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
